### PR TITLE
Update config for new demo instance

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -68,7 +68,7 @@ module.exports = {
     {
       resolve: `gatsby-source-cec`,
       options: {
-        contentServer: `https://prestonso-prestonso.cec.ocp.oraclecloud.com/`,
+        contentServer: `https://demo-oce0001.cec.ocp.oraclecloud.com/`,
         channelToken: process.env.OCE_ACCESS_TOKEN,
         fromCache: false,
       },

--- a/src/pages/press.js
+++ b/src/pages/press.js
@@ -39,7 +39,7 @@ const PressPage = ({ data }) => (
 
 export const query = graphql`
   query {
-    allAppearance(
+    allPrestonSoAppearance(
       sort: { fields: date, order: DESC }
     ) {
       edges {


### PR DESCRIPTION
Using a new OCE demo instance due to expiration of free trial.

Elapsed:
* Update content type name in GraphQL query.

Remaining:
* Update channel ID in `gatsby-config.js`.